### PR TITLE
Default to HTTPS MathJax

### DIFF
--- a/static/main.coffee
+++ b/static/main.coffee
@@ -484,7 +484,7 @@ define [
       if @options.load_mathjax
         script = document.createElement("script")
         script.type = "text/javascript"
-        script.src  = "//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+        script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
         document.getElementsByTagName("head")[0].appendChild(script)
       # inject default styles directly into the page
       if @options.inject_css then $("<style>#{default_css.css}</style>").appendTo('head')


### PR DESCRIPTION
In general, I think these components should be run over HTTPS.

This also makes local development a bit nicer since Chrome resolves `//` as being `file://` when viewing locally (without a webserver).
