### PR TITLE
Readme and example updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The easiest way to get this running locally is to simply set the `url` option to
 
 After installing ipython, run it like so:
 
-    ipython notebook  --NotebookApp.allow_origin=* --no-browser
+    ipython notebook  --NotebookApp.allow_origin='*' --no-browser
 
 Which defaults to running at http://localhost:8888/, and should tell you that.
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,13 @@ python -m SimpleHTTPServer
 
 ```
 
+Or with python3,
+
+```
+python -m http.server
+
+```
+
 and visit it at [localhost:8000](http://localhost:8000) and [localhost:8000/built.html](http://localhost:8000/built.html)
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Four things are required:
 1. A server, either a [tmpnb](https://github.com/zischwartz/tmpnb) server, for lots of users, or simply an [ipython notebook server](http://ipython.org/notebook.html).
 1. A web page with some code examples
 1. A script tag in the page that includes the compiled javascript of `Thebe`, which is in this repo at `static/main-built.js`
-1. jQuery, already included in the page
+1. node-js and bower to install external javascript dependencies.
+
+To install the javascript dependencies, simply run `bower install` in the root of the repository.
 
 Also, [Thebe is a moon of Jupiter](http://en.wikipedia.org/wiki/Thebe_%28moon%29) in case you were wondering. Naming things is hard.
 

--- a/index.html
+++ b/index.html
@@ -68,6 +68,9 @@
           thebe = new main.Thebe({
             // url:"https://tmp39.tmpnb.org",
             url:"https://192.168.99.100:8000",
+            // use the following settings if you are running from a
+            // single-user Jupyter notebook server
+            // url:"http://localhost:8888,
             // tmpnb_mode: false
           });
           // thebe = new main.Thebe({url:"https://tmp39.tmpnb.org"});


### PR DESCRIPTION
This fixes a couple minor issues I ran into while trying out thebe.
1. I've added quotes around the glob-expansion in `NotebookApp.allow-origin`, I think this is safer and will prevent shells like zsh from expanding the glob.
2. Added a short note about how to install the bower dependencies. I've deleted the mention of a bundled jquery.
3. Added a mention of http.server instead of SimpleHTTPServer
4. Added a comment to the example in the root of the repository to emphasize that `tmpnb_mode: false` is necessary for a single-user notebook server.
